### PR TITLE
Added morph data. Only strict clock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [BEAST 2](http://beast2.org) based package for Bayesian multispecies coalescent (MSC) analyses using efficient and parallelised MCMC operators. Also see StarBeast3  [blog post](https://www.beast2.org/2022/03/31/starbeast3.html).
 
 
-This repository branch is for BEAST 2.7. Please see the v2.6 branch for compatability with BEAST 2.6.
+This repository branch is for BEAST 2.7. Please see the v2.6 branch for compatibility with BEAST 2.6.
 
 
 

--- a/build.xml
+++ b/build.xml
@@ -18,9 +18,11 @@
 	<property name="libBeast2" location="${beast2path}/lib" />
 	<property name="srcBeast2" location="${beast2path}/src" />
 	<property name="beast2classpath" location="${beast2path}/build" />
+<!--	<property name="mmpath" location="../morph-models"/>-->
 	<property name="Add_on_dir" value="${release_dir}/add-on" />
 
     <import file="${beast2path}/build.xml" />
+<!--	<import file="${mmpath}/build.xml" />-->
 
 	<property name="main_class_CladeAge" value="beast.app.ca.starbeast3Panel" />
 	<property name="report" value="${buildstarbeast3}/junitreport"/>
@@ -35,6 +37,7 @@
         <pathelement path="${beast2classpath}"/>
         <pathelement path="../BEASTLabs/build"/>
         <pathelement path="../sampled-ancestors/build"/>
+		<pathelement path="../morph-models/build"/>
         <pathelement path="../BeastFX/build"/>
         <pathelement path="../ORC/build"/>
 	</path>
@@ -198,9 +201,9 @@
 			<fileset dir="examples" />
 		</copy>
 		
-		<copy todir="${Add_on_dir}/doc">
-			<fileset dir="doc" includes="starbeast3.pdf"/>
-		</copy>
+<!--		<copy todir="${Add_on_dir}/doc">-->
+<!--			<fileset dir="doc" includes="starbeast3.pdf"/>-->
+<!--		</copy>-->
 		<copy todir="${Add_on_dir}/lib">
 			<fileset dir="${diststarbeast3}" includes="starbeast3.addon.jar" />
 		</copy>

--- a/fxtemplates/StarBeast3.xml
+++ b/fxtemplates/StarBeast3.xml
@@ -247,7 +247,7 @@ ClusterTree/clusterType//'>
 
 		<panel spec="beastfx.app.inputeditor.BeautiPanelConfig" panelname="Species Clock Model" icon='4.png.x' tiptext="Species Clock model" path="init/sharedRateModel/branchRateModel" forceExpansion="TRUE"/>
 		<mergepoint id='aux-sb3-clockmodel-panels'/>
-		
+
 
 		<panel spec="beastfx.app.inputeditor.BeautiPanelConfig" panelname="State" tiptext="Initial state" path="state/stateNode" hasPartitions="none" icon="6.pngx" forceExpansion="TRUE_START_COLLAPSED" isVisible="false"/>
 		<mergepoint id="aux-sb3-initilisation-panels"/>
@@ -462,6 +462,74 @@ ClusterTree/clusterType//'>
 			<mergepoint id="aux-sb3-partitiontemplate"/>
 		</partitiontemplate>
 
+		<alignmentProvider id="Add Morphology to Species Tree" spec='starbeast3.app.beauti.StarBeast3MorphModelAlignmentProvider' template='@StarBEAST3MKTrait'/>
+
+		<subtemplate id='StarBEAST3MKTrait' class='beast.base.evolution.alignment.FilteredAlignment' mainid='$(n)'
+					 suppressInputs = 'morphmodels.evolution.substitutionmodel.LewisMK.stateNumber,
+			morphmodels.evolution.substitutionmodel.LewisMK.datatype,
+			morphmodels.evolution.substitutionmodel.LewisMK.frequencies,
+			morphmodels.evolution.substitutionmodel.LewisMK.proportionInvariant'>
+
+			<![CDATA[
+			<stateNode id="clockRate.c:$(n)" spec="parameter.RealParameter" lower="0.0" value="1.0" estimate="true"/>
+
+			<distribution id="morphTreeLikelihood.$(n)" spec="TreeLikelihood" tree="@Tree.t:Species">
+				<data spec="beast.base.evolution.alignment.FilteredAlignment" id="$(n)" filter="0-end">
+					<userDataType spec="beast.base.evolution.datatype.StandardData" id="morphDataType.$(n)" />
+				</data>
+				<siteModel spec="SiteModel" id="SiteModel.s:$(n)" gammaCategoryCount="0">
+					<substModel spec="morphmodels.evolution.substitutionmodel.LewisMK" id="LewisMK.s:$(n)" datatype="@morphDataType.$(n)"/>
+					<mutationRate spec="parameter.RealParameter" id="mutationRate.s:$(n)" value="1.0" estimate="false"/>
+					<shape spec="parameter.RealParameter" id="gammaShape.s:$(n)" value="1.0" estimate="false"/>
+				</siteModel>
+				<!-- Species-tree strict clock for this morphology partition -->
+
+				<branchRateModel id="strictClockModel.c:$(n)" spec="StrictClockModel" clock.rate="@clockRate.c:$(n)"/>
+			</distribution>
+
+			<prior id="MutationRatePrior.s:$(n)" x="@mutationRate.s:$(n)">
+				<distr spec="OneOnX"/>
+			</prior>
+
+			<prior id="clockRatePrior.c:$(n)" x="@clockRate.c:$(n)">
+				<distr spec="beast.base.inference.distribution.LogNormalDistributionModel" meanInRealSpace="true">
+					<S id="clockRatePriorStdev.s:$(n)" spec="parameter.RealParameter" lower="0.0" value="1.0" estimate="false"/>
+					<M id="clockRatePriorMean.s:$(n)" spec="parameter.RealParameter" lower="0.0" value="1.0" estimate="false"/>
+				</distr>
+			</prior>
+
+			<prior id="GammaShapePrior.s:$(n)" x="@gammaShape.s:$(n)">
+				<distr spec="LogNormalDistributionModel" meanInRealSpace="true" M="1.0" S="2.0"/>
+			</prior>
+
+			<operator id="mutationRateScaler.s:$(n)" spec="ScaleOperator" scaleFactor="0.75" weight="1.0" parameter="@mutationRate.s:$(n)"/>
+			<operator id="gammaShapeScaler.s:$(n)" scaleFactor="0.75" spec="ScaleOperator" weight="1.0" parameter="@gammaShape.s:$(n)"/>
+			<operator id="clockRateScaler.c:$(n)" spec="ScaleOperator" scaleFactor="0.5" weight="3.0" parameter="@clockRate.c:$(n)"/>
+		]]>
+
+			<connect srcID="morphTreeLikelihood.$(n)" targetID="likelihood" inputName="distribution" if="isInitializing"/>
+			<connect method="beastfx.app.inputeditor.SiteModelInputEditor.customConnector"/>
+
+			<connect srcID="MutationRatePrior.s:$(n)" targetID="prior" inputName="distribution" if="nooperator(FixMeanMutationRatesOperator) and inposterior(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true"/>
+
+			<connect srcID="mutationRate.s:$(n)" targetID="state" inputName="stateNode" if="inposterior(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true"/>
+			<connect srcID="gammaShape.s:$(n)" targetID="state" inputName="stateNode" if="inposterior(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true"/>
+			<connect srcID="clockRate.c:$(n)" targetID="state" inputName="stateNode" if="inposterior(Tree.t:$(n)) and clockRate.c:$(n)/estimate=true"/>
+			<connect srcID='clockRatePrior.c:$(n)'  targetID='prior' inputName='distribution' if='inlikelihood(clockRate.c:$(n)) and clockRate.c:$(n)/estimate=true'>Prior on strict clock rate for morphological data c:$(n)</connect>
+
+			<connect srcID="mutationRateScaler.s:$(n)" targetID="mcmc" inputName="operator" if="inposterior(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true"/>
+			<connect srcID="gammaShapeScaler.s:$(n)" targetID="mcmc" inputName="operator" if="inposterior(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true"/>
+			<connect srcID="clockRateScaler.c:$(n)" targetID="mcmc" inputName="operator" if="inposterior(clockRate.c:$(n)) and clockRate.c:$(n)/estimate=true"/>
+
+			<connect srcID="morphTreeLikelihood.$(n)" targetID="tracelog" inputName="log" if="inlikelihood(morphTreeLikelihood.$(n))"/>
+			<connect srcID="mutationRate.s:$(n)" targetID="tracelog" inputName="log" if="inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true"/>
+			<connect srcID="gammaShape.s:$(n)" targetID="tracelog" inputName="log" if="inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true"/>
+			<connect srcID="clockRate.c:$(n)" targetID="tracelog" inputName="log" if="inlikelihood(clockRate.c:$(n)) and clockRate.c:$(n)/estimate=true"/>
+
+			<connect srcID="GammaShapePrior.s:$(n)" targetID="prior" inputName="distribution" if="inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true"/>
+
+		</subtemplate>
+
 		
 		<mergepoint id="sb3SubstModelTemplates"/>
 		<mergepoint id="sb3ClockModelTemplates"/>
@@ -482,6 +550,8 @@ ClusterTree/clusterType//'>
 </taxonset>
 
 <tree id="Tree.t:Species" spec="starbeast3.tree.SpeciesTree" taxonset="@taxonsuperset" estimate="true"/>
+
+
 
 
 <run chainLength="10000000" id="mcmc" spec="MCMC" storeEvery="50000">
@@ -699,8 +769,8 @@ ClusterTree/clusterType//'>
 
 	
 		</sharedRateModel>
-				
-			
+
+
 
     </init>
 	

--- a/fxtemplates/sb3SubstModels.xml
+++ b/fxtemplates/sb3SubstModels.xml
@@ -445,6 +445,17 @@ RateGTPrior/index/=Priors/RateGTRPrior/,
             <frequencies id='equalFreqs.s:$(n)' spec='Frequencies' data='@$(n)' estimate='false'/>
 ]]>
         </subtemplate>
+
+        <!-- LewisMK substitution model -->
+        <subtemplate id='LewisMK' class='morphmodels.evolution.substitutionmodel.LewisMK' mainid='LewisMK.s:$(n)'
+                     suppressInputs='morphmodels.evolution.substitutionmodel.LewisMK.stateNumber,
+			morphmodels.evolution.substitutionmodel.LewisMK.datatype,
+			morphmodels.evolution.substitutionmodel.LewisMK.frequencies,
+			morphmodels.evolution.substitutionmodel.LewisMK.proportionInvariant'>
+            <![CDATA[
+    <plugin spec='morphmodels.evolution.substitutionmodel.LewisMK' id='LewisMK.s:$(n)'/>
+]]>
+        </subtemplate>
     
 
 

--- a/src/starbeast3/core/SampleTimeLog.java
+++ b/src/starbeast3/core/SampleTimeLog.java
@@ -17,7 +17,7 @@ public class SampleTimeLog extends CalculationNode implements Loggable, Function
 	
 	
 	
-	final public Input<OperatorSchedule> operatorScheduleInput = new Input<>("schedule", "The oeprator schedule, used for determining number of proposals", Input.Validate.REQUIRED);
+	final public Input<OperatorSchedule> operatorScheduleInput = new Input<>("schedule", "The operator schedule, used for determining number of proposals", Input.Validate.REQUIRED);
 
   	protected LocalDateTime dateTimeLast_l;
   	protected LocalDateTime dateTimeFirst_l;

--- a/version.xml
+++ b/version.xml
@@ -3,7 +3,8 @@
 	<depends on='BEAST.app' atleast='2.7.3'/>
 	<depends on='BEASTLabs' atleast='2.0.0'/>
 	<depends on='ORC' atleast='1.2.0'/>
-	<depends on="SA" atleast="2.1.0"/> 
+	<depends on="SA" atleast="2.1.0"/>
+    <depends on="MM" atleast="1.2.1"/>
 
     <service type="beastfx.app.inputeditor.InputEditor">
         <provider classname="starbeast3.app.beauti.StarBeast3ClockInputEditor"/>
@@ -18,6 +19,7 @@
 
     <service type="beast.base.core.BEASTInterface">
         <provider classname="starbeast3.app.beauti.StarBeastAlignmentProvider3"/>
+        <provider classname="starbeast3.app.beauti.StarBeast3MorphModelAlignmentProvider"/>
         <provider classname="starbeast3.simulation.DirectSimulator"/>
         <provider classname="starbeast3.core.MCMCsb3"/>
         <provider classname="starbeast3.core.OperatorScheduleRecalculator"/>


### PR DESCRIPTION
BEAUti template changes to:
- add morphological data to species tree
- only strict clock is available for morph data through BEAUti for now
- w.r.t. morph data, analyses that were possible to set up for sb2 are now possible for sb3


Also couple typo fixes. Added dependency to morph-models package.